### PR TITLE
UHF-9212: Install phpstan

### DIFF
--- a/src/Update/UpdateOptions.php
+++ b/src/Update/UpdateOptions.php
@@ -13,7 +13,7 @@ final class UpdateOptions {
    * Constructs a new instance.
    *
    * @param array $ignoreFiles
-   *   Whether to allow files to be ignored.
+   *   Files to ignore. Leave empty to never ignore anything.
    * @param bool $updateExternalPackages
    *   Whether to update external packages.
    * @param bool $selfUpdate


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_drupal_tools:dev-UHF-X-support-migrations`

## How to test

- Run `drush helfi:tools:update-platform --no-self-update` 
- Make sure the command succeeds and phpstan libraries are installed as dev dependencies:

![image](https://github.com/City-of-Helsinki/drupal-tools/assets/771113/1aea782a-b21b-440e-a7d4-c4d70990b4a9)

