### PR TITLE
UHF-9718: Markdown table formatter

### DIFF
--- a/src/Drush/Commands/PackageScannerDrushCommands.php
+++ b/src/Drush/Commands/PackageScannerDrushCommands.php
@@ -9,10 +9,12 @@ use Consolidation\AnnotatedCommand\CommandResult;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Component\DependencyInjection\ContainerInterface;
 use Drupal\helfi_api_base\Package\VersionChecker;
+use DrupalTools\OutputFormatters\MarkdownTableFormatter;
 use Drush\Attributes\Argument;
 use Drush\Attributes\Command;
 use Drush\Attributes\FieldLabels;
 use Drush\Commands\DrushCommands;
+use Psr\Container\ContainerInterface as DrushContainer;
 
 /**
  * A drush command to check whether given Helfi packages are up-to-date.
@@ -33,7 +35,14 @@ final class PackageScannerDrushCommands extends DrushCommands {
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $container): self {
+  public static function create(ContainerInterface $container, DrushContainer $drush): self {
+    /** @var \Drush\Formatters\DrushFormatterManager $formatterManager */
+    $formatterManager = $drush->get('formatterManager');
+
+    // @todo Figure out if there's a better way to inject this service.
+    if (!$formatterManager->hasFormatter('markdown_table')) {
+      $formatterManager->addFormatter('markdown_table', new MarkdownTableFormatter());
+    }
     return new self(
       $container->get('helfi_api_base.package_version_checker'),
     );

--- a/src/OutputFormatters/MarkdownTableFormatter.php
+++ b/src/OutputFormatters/MarkdownTableFormatter.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalTools\OutputFormatters;
+
+use Consolidation\OutputFormatters\Exception\IncompatibleDataException;
+use Consolidation\OutputFormatters\Formatters\FormatterInterface;
+use Consolidation\OutputFormatters\Formatters\HumanReadableFormat;
+use Consolidation\OutputFormatters\Formatters\MetadataFormatterInterface;
+use Consolidation\OutputFormatters\Formatters\MetadataFormatterTrait;
+use Consolidation\OutputFormatters\Formatters\RenderDataInterface;
+use Consolidation\OutputFormatters\Formatters\RenderTableDataTrait;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\TableDataInterface;
+use Consolidation\OutputFormatters\Transformations\TableTransformation;
+use Consolidation\OutputFormatters\Validate\ValidDataTypesInterface;
+use Consolidation\OutputFormatters\Validate\ValidDataTypesTrait;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Formats a table using markdown formatter.
+ */
+final class MarkdownTableFormatter implements FormatterInterface, ValidDataTypesInterface, RenderDataInterface, MetadataFormatterInterface, HumanReadableFormat {
+
+  use ValidDataTypesTrait;
+  use RenderTableDataTrait;
+  use MetadataFormatterTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function write(
+    OutputInterface $output,
+    $data,
+    FormatterOptions $options
+  ) : void {
+    assert($data instanceof TableTransformation);
+    $headers = $data->getHeaders();
+    $rows = $data->getTableData();
+
+    $output->write(self::renderLine($headers));
+    $output->write(self::renderLine(array_map(fn() => '--', $headers)));
+    $output->write(implode('', array_map(fn(array $row) => self::renderLine($row), $rows)));
+  }
+
+  /**
+   * Renders a line.
+   *
+   * @param array $fields
+   *   Renders the given fields.
+   *
+   * @return string
+   *   The rendered line.
+   */
+  private static function renderLine(array $fields) : string {
+    return implode(' | ', $fields) . "\n";
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @return array{\ReflectionClass<\Consolidation\OutputFormatters\StructuredData\RowsOfFields|\Consolidation\OutputFormatters\StructuredData\PropertyList>}
+   *   The valid data types.
+   */
+  public function validDataTypes() : array {
+    return [
+      new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\RowsOfFields'),
+      new \ReflectionClass('\Consolidation\OutputFormatters\StructuredData\PropertyList'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($structuredData) : TableDataInterface {
+    // If the provided data was of class RowsOfFields
+    // or PropertyList, it will be converted into
+    // a TableTransformation object by the restructure call.
+    if (!$structuredData instanceof TableDataInterface) {
+      throw new IncompatibleDataException(
+        $this,
+        $structuredData,
+        $this->validDataTypes()
+      );
+    }
+    return $structuredData;
+  }
+
+}

--- a/tests/src/Unit/OutputFormatters/MarkdownTableFormatterTest.php
+++ b/tests/src/Unit/OutputFormatters/MarkdownTableFormatterTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_drupal_tools\Unit;
+
+use Consolidation\OutputFormatters\Exception\IncompatibleDataException;
+use Consolidation\OutputFormatters\Options\FormatterOptions;
+use Consolidation\OutputFormatters\StructuredData\PropertyList;
+use Consolidation\OutputFormatters\StructuredData\RestructureInterface;
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Consolidation\OutputFormatters\StructuredData\TableDataInterface;
+use Consolidation\OutputFormatters\StructuredData\UnstructuredData;
+use DrupalTools\OutputFormatters\MarkdownTableFormatter;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Tests Markdown table formatter.
+ *
+ * @group helfi_drupal_tools
+ */
+class MarkdownTableFormatterTest extends TestCase {
+
+  /**
+   * Make sure an exception is thrown for incompatible data.
+   */
+  public function testInvalidDataTypeException() : void {
+    $formatter = new MarkdownTableFormatter();
+    $data = new UnstructuredData([]);
+    $this->expectException(IncompatibleDataException::class);
+    $formatter->validate($data->restructure(new FormatterOptions()));
+  }
+
+  /**
+   * Tests validation.
+   *
+   * @dataProvider validateTestData
+   */
+  public function testValidate(RestructureInterface $data) : void {
+    $formatter = new MarkdownTableFormatter();
+    $data = $formatter->validate($data->restructure(new FormatterOptions()));
+    $this->assertInstanceOf(TableDataInterface::class, $data);
+  }
+
+  /**
+   * A data provider for validation tests.
+   *
+   * @return array
+   *   The data.
+   */
+  public function validateTestData() : array {
+    return [
+      [new RowsOfFields([])],
+      [new PropertyList([])],
+    ];
+  }
+
+  /**
+   * Make sure the given table is formatted as markdown.
+   */
+  public function testMarkdownTableFormatter() : void {
+    $formatter = new MarkdownTableFormatter();
+    $output = new BufferedOutput();
+    $options = new FormatterOptions([
+      FormatterOptions::FIELD_LABELS => [
+        'name' => 'Name',
+        'version' => 'Version',
+        'latest' => 'Latest',
+      ],
+    ]);
+    $data = new RowsOfFields([
+      [
+        'name' => 'Test',
+        'version' => '1.0.0',
+        'latest' => '1.0.2',
+      ],
+      [
+        'name' => 'Test 2',
+        'version' => '',
+        'latest' => '',
+      ],
+    ]);
+    $data = $data->restructure($options);
+    $formatter->write($output, $data, $options);
+
+    $expected = "Name | Version | Latest\n";
+    $expected .= "-- | -- | --\n";
+    $expected .= "Test | 1.0.0 | 1.0.2\n";
+    $expected .= "Test 2 |  | \n";
+
+    $this->assertEquals($expected, $output->fetch());
+  }
+
+}

--- a/tests/src/Unit/OutputFormatters/MarkdownTableFormatterTest.php
+++ b/tests/src/Unit/OutputFormatters/MarkdownTableFormatterTest.php
@@ -69,6 +69,15 @@ class MarkdownTableFormatterTest extends TestCase {
         'latest' => 'Latest',
       ],
     ]);
+
+    $data = new RowsOfFields([]);
+    $data = $data->restructure($options);
+    $formatter->write($output, $data, $options);
+
+    $expected = "Name | Version | Latest\n";
+    $expected .= "-- | -- | --\n";
+    $this->assertEquals($expected, $output->fetch());
+
     $data = new RowsOfFields([
       [
         'name' => 'Test',


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_drupal_tools:dev-UHF-9718`

## How to test

- Run `drush helfi:tools:check-composer-versions /app/composer.lock --format=markdown_table`
- Make sure a valid markdown table is printed