### PR TITLE
UHF-9576: Add cron job for linked events migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "jangregor/phpstan-prophecy": "^1.0",
         "phpunit/phpunit": "^9.6"
     },
+    "prefer-stable": true,
     "autoload": {
         "psr-4": {
             "DrupalTools\\": "src"
@@ -51,7 +52,8 @@
         "allow-plugins": {
             "composer/installers": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": false
         }
     },
     "extra": {

--- a/src/Drush/Commands/UpdateDrushCommands.php
+++ b/src/Drush/Commands/UpdateDrushCommands.php
@@ -251,6 +251,7 @@ final class UpdateDrushCommands extends DrushCommands {
         'docker/openshift/entrypoints/20-deploy.sh',
         'docker/openshift/crons/content-scheduler.sh',
         'docker/openshift/crons/migrate-tpr.sh',
+        'docker/openshift/crons/linked-events.sh',
         'docker/openshift/crons/prestop-hook.sh',
         'docker/openshift/crons/purge-queue.sh',
         'docker/openshift/crons/update-translations.sh',


### PR DESCRIPTION
## What was done

- Add `docker/openshift/crons/linked-events.sh` to automatic updates.

## Other pull requests

- https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/215