### PR TITLE
UHF-10713: Add phpstan/extension-installer to composer allow-plugins

### DIFF
--- a/src/Update/migrations.php
+++ b/src/Update/migrations.php
@@ -272,3 +272,18 @@ function drupal_tools_update_13() : UpdateResult {
     'Removed direct dependency to ' . implode(', ', $remove),
   ]);
 }
+
+/**
+ * Allow phpstan/extension-installer. This was accidentally removed update 13.
+ */
+function drupal_tools_update_14() : UpdateResult {
+  // Ensure drupal/core-dev is required.
+  (new Process([
+    'composer', 'config', 'allow-plugins.phpstan/extension-installer', 'true', '--no-interaction',
+  ]))
+    ->run();
+
+  return new UpdateResult([
+    'Added phpstan/extension-installer to allow-plugins',
+  ]);
+}


### PR DESCRIPTION
## How to test

- In `update-config` branch, `composer install --no-interaction` does not work
- Run: `composer require drupal/helfi_drupal_tools:dev-UHF-10713`
- Run: `drush helfi:tools:update-platform --no-self-update`
- In `update-config` branch, `composer install --no-interaction` should work