### PR TITLE
UHF-11676: Remove docker/openshift/crons/linked-events.sh

### DIFF
--- a/src/Drush/Commands/UpdateDrushCommands.php
+++ b/src/Drush/Commands/UpdateDrushCommands.php
@@ -212,7 +212,6 @@ final class UpdateDrushCommands extends DrushCommands {
         'docker/openshift/entrypoints/20-deploy.sh',
         'docker/openshift/crons/content-scheduler.sh',
         'docker/openshift/crons/migrate-tpr.sh',
-        'docker/openshift/crons/linked-events.sh',
         'docker/openshift/crons/prestop-hook.sh',
         'docker/openshift/crons/purge-queue.sh',
         'docker/openshift/crons/update-translations.sh',

--- a/src/Update/migrations.php
+++ b/src/Update/migrations.php
@@ -325,3 +325,16 @@ function drupal_tools_update_17(UpdateOptions $options, FileManager $fileManager
     'Removed docker/openshift/custom.locations',
   ]);
 }
+
+/**
+ * UHF-11676: Remove 'docker/openshift/crons/linked-events.sh'.
+ */
+function drupal_tools_update_18(UpdateOptions $options, FileManager $fileManager) : UpdateResult {
+  $fileManager->removeFiles($options, [
+    'docker/openshift/crons/linked-events.sh',
+  ]);
+
+  return new UpdateResult([
+    'Removed docker/openshift/crons/linked-events.sh',
+  ]);
+}


### PR DESCRIPTION
# [UHF-11676](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11676)
<!-- What problem does this solve? -->

This migration is no longer needed. The required data is now loaded by custom widget. See related platform_config change for more details

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-helfi-platform-config/pull/978

[UHF-11676]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ