### PR TITLE
UHF-11475: Require drush v13

### DIFF
--- a/src/Update/migrations.php
+++ b/src/Update/migrations.php
@@ -340,13 +340,13 @@ function drupal_tools_update_18(UpdateOptions $options, FileManager $fileManager
 }
 
 /**
- * UHF-11475: Update drush v13.
+ * UHF-11475: Remove direct dependency to drush.
  */
 function drupal_tools_update_19(UpdateOptions $options, FileManager $fileManager) : UpdateResult {
-  (new Process(['composer', 'require', 'drush/drush:^13', '-W']))
+  (new Process(['composer', 'remove', 'drush/drush']))
     ->run();
 
   return new UpdateResult([
-    'Updated drush to v13.',
+    'Removed direct dependency to drush',
   ]);
 }


### PR DESCRIPTION
# [UHF-11475](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11475)

## How to install
- Run: `composer require drupal/helfi_drupal_tools:dev-UHF-11475-drush-13`
- Run: `drush helfi:tools:update-platform --no-self-update`
- Run: `docker compose pull; make shell; composer install`

## How to test
- [ ] `drush --version` should report v13
- [ ] Set a breakpoint to any drush command and run it. XDebug should work. 

[UHF-11475]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ