### PR TITLE
UHF-13168: Adding .gitignore to platfrom update command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
             "phpstan/extension-installer": true,
             "php-http/discovery": false,
             "tbachert/spi": false,
-            "drupal/core-composer-scaffold": false
+            "drupal/core-composer-scaffold": false,
+            "symfony/runtime": false
         }
     },
     "extra": {

--- a/src/Drush/Commands/UpdateDrushCommands.php
+++ b/src/Drush/Commands/UpdateDrushCommands.php
@@ -242,6 +242,7 @@ final class UpdateDrushCommands extends DrushCommands {
         'tests/dtt/src/ExistingSite/ModuleEnabledTest.php',
       ])
       ->updateFiles($options, [
+        '.gitignore.dist' => '.gitignore',
         '.github/dependabot.yml.dist' => '.github/dependabot.yml',
         '.github/workflows/test.yml.dist' => '.github/workflows/test.yml',
         '.github/workflows/artifact.yml.dist' => '.github/workflows/artifact.yml',

--- a/tests/src/Unit/UpdateDrushCommandsTest.php
+++ b/tests/src/Unit/UpdateDrushCommandsTest.php
@@ -8,6 +8,7 @@ use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
 use DrupalTools\Drush\Commands\UpdateDrushCommands;
 use DrupalTools\Update\FileManager;
 use DrupalTools\Update\UpdateHookManager;
+use DrupalTools\Update\UpdateOptions;
 use Drush\Commands\DrushCommands;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
@@ -129,6 +130,41 @@ class UpdateDrushCommandsTest extends TestCase {
         'root' => '.',
       ]));
     $this->assertEquals(DrushCommands::EXIT_FAILURE_WITH_CLARITY, $return);
+  }
+
+  /**
+   * Tests that files are added and updated.
+   */
+  public function testUpdatePlatformAddsAndUpdatesFiles() : void {
+    $fs = $this->prophesize(Filesystem::class);
+    $fs->exists(Argument::containingString('.git'))
+      ->shouldBeCalled()
+      ->willReturn(TRUE);
+
+    $fileManager = $this->prophesize(FileManager::class);
+    $fileManager->updateFiles(Argument::type(UpdateOptions::class), Argument::type('array'))
+      ->shouldBeCalledTimes(2)
+      ->willReturn($fileManager->reveal());
+    $fileManager->addFiles(Argument::type(UpdateOptions::class), Argument::type('array'))
+      ->shouldBeCalledOnce()
+      ->willReturn($fileManager->reveal());
+
+    $output = $this->prophesize(OutputStyle::class);
+    $output->note('Running update hooks ...')->shouldBeCalled();
+    $output->note('Checking files ...')->shouldBeCalled();
+
+    $return = $this->getMockSut(
+      filesystem: $fs->reveal(),
+      fileManager: $fileManager->reveal(),
+      output: $output->reveal(),
+    )->updatePlatform(array_merge(UpdateDrushCommands::DEFAULT_OPTIONS, [
+      'root' => '.',
+      'self-update' => FALSE,
+      'run-migrations' => FALSE,
+      'ignore-files' => FALSE,
+    ]));
+
+    $this->assertEquals(DrushCommands::EXIT_SUCCESS, $return);
   }
 
 }


### PR DESCRIPTION
# [UHF-13168](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13168)

## What was done

* Added `.gitignore.dist` --> `.gitignore` file copy to `helfi:tools:update-platform`-command.

## How to install
<!-- Describe steps how to install the features. Default steps are provided. -->
* Make sure your instance is up and running latest version of dev-branch
  * `git checkout dev && git pull origin dev`
  * `make fresh`
* Update drupal tools to this feature branch version
  * `composer require drupal/helfi_drupal_tools:dev-UHF-13168`

## How to test
<!-- Describe steps how to test the features. Add as many steps as you want to be tested -->
* First edit the `.gitignore` in the site repo root, adding a row somewhere with test content like `test-here`.
* [x] Then run `drush helfi:tools:update-platform --no-self-update`; the above test row in `.gitignore` should be gone, and file contents should be identical to https://github.com/City-of-Helsinki/drupal-helfi-platform/blob/main/.gitignore.dist (so that's the main branch version, without the changes from https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/389 yet)
* [x] Check that the code follows our standards

## Links to related PRs

* https://github.com/City-of-Helsinki/drupal-helfi-platform/pull/389


[UHF-13168]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ