### PR TITLE
UHF-12824: Refactored ComposerPatchesCommand to use new Symfony command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run:
           vendor/bin/phpunit -c tests/phpunit.xml tests/
 
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/Drush/Commands/ComposerPatchesCommand.php
+++ b/src/Drush/Commands/ComposerPatchesCommand.php
@@ -13,19 +13,29 @@ use Drush\Attributes\Bootstrap;
 use Drush\Attributes\Command;
 use Drush\Attributes\FieldLabels;
 use Drush\Boot\DrupalBootLevels;
-use Drush\Commands\DrushCommands;
+use Drush\Commands\AutowireTrait;
+use Drush\Formatters\FormatterTrait;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * A drush command to check composer patches.
  */
 #[Bootstrap(level: DrupalBootLevels::NONE)]
-final class ComposerPatchesCommands extends DrushCommands {
+#[AsCommand(
+  name: 'helfi:tools:check-composer-patches',
+  description: 'Checks whether Composer patches are installed correctly.',
+)]
+final class ComposerPatchesCommand extends \Symfony\Component\Console\Command\Command {
 
-  use FormatterManagerTrait;
+  use AutowireTrait;
+  use FormatterTrait;
 
   public function __construct(
     private readonly ClientInterface $client,
@@ -33,16 +43,21 @@ final class ComposerPatchesCommands extends DrushCommands {
     parent::__construct();
   }
 
+  protected function configure(): void {
+    $this
+      ->addArgument('file', InputArgument::REQUIRED, 'Path to composer.lock file');
+  }
+
   /**
    * {@inheritdoc}
    */
-  public static function create(ContainerInterface $drush): self {
+  /*public static function create(ContainerInterface $drush): self {
     self::populateFormatterManager($drush);
 
     return new self(
       new Client(),
     );
-  }
+  }*/
 
   /**
    * Checks if the patch is valid.
@@ -130,22 +145,23 @@ final class ComposerPatchesCommands extends DrushCommands {
   /**
    * Checks whether Composer patches are installed correctly.
    *
-   * @param string $file
-   *   The path to 'composer.lock' file.
-   * @param array $options
-   *   The options.
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   *   The input.
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   *   The output.
    *
-   * @return \Consolidation\AnnotatedCommand\CommandResult
-   *   The result.
+   * @return int
+   *   The exit code.
    */
-  #[Command(name: 'helfi:tools:check-composer-patches')]
   #[Argument(name: 'file', description: 'Path to composer.lock file')]
   #[FieldLabels(labels: [
     'package' => 'package',
     'description' => 'Patch description',
     'patch' => 'Patch',
   ])]
-  public function execute(string $file, array $options = ['format' => 'table']) : CommandResult {
+  public function execute(InputInterface $input, OutputInterface $output) : int {
+    $file = $input->getArgument('file');
+
     if (!realpath($file)) {
       throw new VersionCheckException('Composer lock file not found');
     }
@@ -182,10 +198,12 @@ final class ComposerPatchesCommands extends DrushCommands {
     }
 
     if ($failed) {
-      return CommandResult::dataWithExitCode(new RowsOfFields($failed), self::EXIT_FAILURE_WITH_CLARITY);
+      $this->writeFormattedOutput($input, $output, new RowsOfFields($failed));
+      return self::FAILURE;
     }
 
-    return CommandResult::dataWithExitCode(new RowsOfFields($rows), self::EXIT_SUCCESS);
+    $this->writeFormattedOutput($input, $output, new RowsOfFields($rows));
+    return self::SUCCESS;
   }
 
 }

--- a/src/Drush/Commands/ComposerPatchesCommand.php
+++ b/src/Drush/Commands/ComposerPatchesCommand.php
@@ -5,59 +5,56 @@ declare(strict_types=1);
 namespace DrupalTools\Drush\Commands;
 
 use Consolidation\AnnotatedCommand\CommandResult;
+use Consolidation\OutputFormatters\FormatterManager;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
-use DrupalTools\OutputFormatters\FormatterManagerTrait;
 use DrupalTools\Package\Exception\VersionCheckException;
-use Drush\Attributes\Argument;
 use Drush\Attributes\Bootstrap;
-use Drush\Attributes\Command;
 use Drush\Attributes\FieldLabels;
+use Drush\Attributes\Formatter;
 use Drush\Boot\DrupalBootLevels;
 use Drush\Commands\AutowireTrait;
 use Drush\Formatters\FormatterTrait;
-use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\GuzzleException;
-use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * A drush command to check composer patches.
+ * A Drush command to check composer patches.
  */
-#[Bootstrap(level: DrupalBootLevels::NONE)]
 #[AsCommand(
   name: 'helfi:tools:check-composer-patches',
   description: 'Checks whether Composer patches are installed correctly.',
 )]
-final class ComposerPatchesCommand extends \Symfony\Component\Console\Command\Command {
+#[Formatter(returnType: RowsOfFields::class, defaultFormatter: 'table')]
+#[FieldLabels(labels: [
+  'package' => 'package',
+  'description' => 'Patch description',
+  'patch' => 'Patch',
+])]
+#[Bootstrap(level: DrupalBootLevels::ROOT)]
+final class ComposerPatchesCommand extends Command {
 
   use AutowireTrait;
   use FormatterTrait;
 
   public function __construct(
     private readonly ClientInterface $client,
+    protected readonly FormatterManager $formatterManager,
   ) {
     parent::__construct();
-  }
-
-  protected function configure(): void {
-    $this
-      ->addArgument('file', InputArgument::REQUIRED, 'Path to composer.lock file');
   }
 
   /**
    * {@inheritdoc}
    */
-  /*public static function create(ContainerInterface $drush): self {
-    self::populateFormatterManager($drush);
-
-    return new self(
-      new Client(),
-    );
-  }*/
+  protected function configure(): void {
+    $this
+      ->addArgument('file', InputArgument::REQUIRED, 'Path to composer.lock file');
+  }
 
   /**
    * Checks if the patch is valid.
@@ -153,23 +150,37 @@ final class ComposerPatchesCommand extends \Symfony\Component\Console\Command\Co
    * @return int
    *   The exit code.
    */
-  #[Argument(name: 'file', description: 'Path to composer.lock file')]
-  #[FieldLabels(labels: [
-    'package' => 'package',
-    'description' => 'Patch description',
-    'patch' => 'Patch',
-  ])]
   public function execute(InputInterface $input, OutputInterface $output) : int {
-    $file = $input->getArgument('file');
+    $file = (string) $input->getArgument('file');
 
-    if (!realpath($file)) {
+    $result = $this->doExecute($file);
+    $this->writeFormattedOutput($input, $output, $result->getOutputData());
+
+    return $result->getExitCode();
+  }
+
+  /**
+   * The actual execute command.
+   *
+   * @param string $file
+   *   The composer.lock file.
+   *
+   * @return \Consolidation\AnnotatedCommand\CommandResult
+   *   The command result.
+   *
+   * @throws \JsonException
+   */
+  public function doExecute(string $file): CommandResult {
+    if (!realpath($file) || !file_exists($file)) {
       throw new VersionCheckException('Composer lock file not found');
     }
     $rows = $failed = [];
 
-    foreach ($this->getPatchedPackages($file) as $name => $patches) {
+    $packages = $this->getPatchedPackages($file);
+
+    foreach ($packages as $name => $patches) {
       $rows[] = [
-        'package' => $name,
+        'package' => '<info>' . $name . '</info>',
         'description' => '',
         'patch' => '',
       ];
@@ -192,18 +203,14 @@ final class ComposerPatchesCommand extends \Symfony\Component\Console\Command\Co
         if (!$this->isValidPatch($patch['patch'])) {
           $failed[] = $row;
         }
-
         $rows[] = $row;
       }
     }
 
     if ($failed) {
-      $this->writeFormattedOutput($input, $output, new RowsOfFields($failed));
-      return self::FAILURE;
+      return CommandResult::dataWithExitCode(new RowsOfFields($failed), self::FAILURE);
     }
-
-    $this->writeFormattedOutput($input, $output, new RowsOfFields($rows));
-    return self::SUCCESS;
+    return CommandResult::dataWithExitCode(new RowsOfFields($rows), self::SUCCESS);
   }
 
 }

--- a/tests/src/Unit/ComposerPatchesCommandsTest.php
+++ b/tests/src/Unit/ComposerPatchesCommandsTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Tests Composer patches Drush commands.
@@ -27,14 +29,31 @@ class ComposerPatchesCommandsTest extends TestCase {
   use ApiTestTrait;
 
   /**
-   * Tests ::create().
+   * Gets the SUT.
+   *
+   * @param \GuzzleHttp\ClientInterface $client
+   *   The HTTP client.
+   *
+   * @return \DrupalTools\Drush\Commands\ComposerPatchesCommand
+   *   The SUT.
+   */
+  public function getSut(ClientInterface $client) : ComposerPatchesCommand {
+    $container = new Container();
+    $container->add(FormatterManager::class, new FormatterManager());
+    $container->add(ClientInterface::class, $client);
+    return ComposerPatchesCommand::create($container);
+  }
+
+  /**
+   * Tests empty composer.lock path.
    */
   #[Test]
-  public function testCreate(): void {
-    $this->expectNotToPerformAssertions();
-    $container = new Container();
-    $container->add('formatterManager', new FormatterManager());
-    ComposerPatchesCommand::create($container);
+  public function testEmptyPath(): void {
+    $this->expectException(VersionCheckException::class);
+    $client = $this->prophesize(ClientInterface::class)->reveal();
+    $sut = $this->getSut($client);
+    $input = $this->prophesize(InputInterface::class);
+    $sut->execute($input->reveal(), $this->prophesize(OutputInterface::class)->reveal());
   }
 
   /**
@@ -43,9 +62,12 @@ class ComposerPatchesCommandsTest extends TestCase {
   #[Test]
   public function testComposerLockFound(): void {
     $this->expectException(VersionCheckException::class);
-    $client = $this->prophesize(ClientInterface::class);
-    $sut = new ComposerPatchesCommand($client->reveal());
-    $sut->execute('nonexistent');
+    $client = $this->prophesize(ClientInterface::class)->reveal();
+    $sut = $this->getSut($client);
+    $input = $this->prophesize(InputInterface::class);
+    $input->getArgument('file')
+      ->willReturn('nonexistent');
+    $sut->execute($input->reveal(), $this->prophesize(OutputInterface::class)->reveal());
   }
 
   /**
@@ -55,8 +77,8 @@ class ComposerPatchesCommandsTest extends TestCase {
   public function testInvalidJson(): void {
     $this->expectException(\JsonException::class);
     $client = $this->prophesize(ClientInterface::class);
-    $sut = new ComposerPatchesCommand($client->reveal());
-    $sut->execute(__DIR__ . '/../../fixtures/invalid.lock');
+    $sut = $this->getSut($client->reveal());
+    $sut->doExecute(__DIR__ . '/../../fixtures/invalid.lock');
   }
 
   /**
@@ -67,14 +89,14 @@ class ComposerPatchesCommandsTest extends TestCase {
     $client = $this->createMockHttpClient([
       new Response(200),
     ]);
-    $sut = new ComposerPatchesCommand($client);
-    $result = $sut->execute(__DIR__ . '/../../fixtures/composer.lock');
-    $this->assertEquals(ComposerPatchesCommand::EXIT_SUCCESS, $result->getExitCode());
+    $sut = $this->getSut($client);
+    $result = $sut->doExecute(__DIR__ . '/../../fixtures/composer.lock');
+    $this->assertEquals(ComposerPatchesCommand::SUCCESS, $result->getExitCode());
     $this->assertInstanceOf(RowsOfFields::class, $result->getOutputData());
 
     $this->assertEquals([
       [
-        'package' => 'drupal/helfi_api_base',
+        'package' => '<info>drupal/helfi_api_base</info>',
         'description' => '',
         'patch' => '',
       ],
@@ -94,9 +116,9 @@ class ComposerPatchesCommandsTest extends TestCase {
     $client = $this->createMockHttpClient([
       new Response(404),
     ]);
-    $sut = new ComposerPatchesCommand($client);
-    $result = $sut->execute(__DIR__ . '/../../fixtures/composer.lock');
-    $this->assertEquals(ComposerPatchesCommand::EXIT_FAILURE_WITH_CLARITY, $result->getExitCode());
+    $sut = $this->getSut($client);
+    $result = $sut->doExecute(__DIR__ . '/../../fixtures/composer.lock');
+    $this->assertEquals(ComposerPatchesCommand::FAILURE, $result->getExitCode());
     $this->assertInstanceOf(RowsOfFields::class, $result->getOutputData());
 
     $this->assertEquals([

--- a/tests/src/Unit/ComposerPatchesCommandsTest.php
+++ b/tests/src/Unit/ComposerPatchesCommandsTest.php
@@ -7,7 +7,7 @@ namespace Drupal\Tests\helfi_drupal_tools\Unit;
 use Consolidation\OutputFormatters\FormatterManager;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
-use DrupalTools\Drush\Commands\ComposerPatchesCommands;
+use DrupalTools\Drush\Commands\ComposerPatchesCommand;
 use DrupalTools\Package\Exception\VersionCheckException;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7\Response;
@@ -34,7 +34,7 @@ class ComposerPatchesCommandsTest extends TestCase {
     $this->expectNotToPerformAssertions();
     $container = new Container();
     $container->add('formatterManager', new FormatterManager());
-    ComposerPatchesCommands::create($container);
+    ComposerPatchesCommand::create($container);
   }
 
   /**
@@ -44,7 +44,7 @@ class ComposerPatchesCommandsTest extends TestCase {
   public function testComposerLockFound(): void {
     $this->expectException(VersionCheckException::class);
     $client = $this->prophesize(ClientInterface::class);
-    $sut = new ComposerPatchesCommands($client->reveal());
+    $sut = new ComposerPatchesCommand($client->reveal());
     $sut->execute('nonexistent');
   }
 
@@ -55,7 +55,7 @@ class ComposerPatchesCommandsTest extends TestCase {
   public function testInvalidJson(): void {
     $this->expectException(\JsonException::class);
     $client = $this->prophesize(ClientInterface::class);
-    $sut = new ComposerPatchesCommands($client->reveal());
+    $sut = new ComposerPatchesCommand($client->reveal());
     $sut->execute(__DIR__ . '/../../fixtures/invalid.lock');
   }
 
@@ -67,9 +67,9 @@ class ComposerPatchesCommandsTest extends TestCase {
     $client = $this->createMockHttpClient([
       new Response(200),
     ]);
-    $sut = new ComposerPatchesCommands($client);
+    $sut = new ComposerPatchesCommand($client);
     $result = $sut->execute(__DIR__ . '/../../fixtures/composer.lock');
-    $this->assertEquals(ComposerPatchesCommands::EXIT_SUCCESS, $result->getExitCode());
+    $this->assertEquals(ComposerPatchesCommand::EXIT_SUCCESS, $result->getExitCode());
     $this->assertInstanceOf(RowsOfFields::class, $result->getOutputData());
 
     $this->assertEquals([
@@ -94,9 +94,9 @@ class ComposerPatchesCommandsTest extends TestCase {
     $client = $this->createMockHttpClient([
       new Response(404),
     ]);
-    $sut = new ComposerPatchesCommands($client);
+    $sut = new ComposerPatchesCommand($client);
     $result = $sut->execute(__DIR__ . '/../../fixtures/composer.lock');
-    $this->assertEquals(ComposerPatchesCommands::EXIT_FAILURE_WITH_CLARITY, $result->getExitCode());
+    $this->assertEquals(ComposerPatchesCommand::EXIT_FAILURE_WITH_CLARITY, $result->getExitCode());
     $this->assertInstanceOf(RowsOfFields::class, $result->getOutputData());
 
     $this->assertEquals([


### PR DESCRIPTION
## How to install
- `composer require drupal/helfi_drupal_tools:dev-UHF-12824`

## How to test 
* [x] Run `drush helfi:tools:check-composer-patches /app/composer.lock`
* [x] The command should return a list of patches